### PR TITLE
Remove script running lines and update pyproject.toml

### DIFF
--- a/aisdb/tests/test_014_marinetraffic.py
+++ b/aisdb/tests/test_014_marinetraffic.py
@@ -76,10 +76,3 @@ def test_vessel_finder():
 
     assert dict_
     assert dict_2
-
-
-if __name__ == "__main__":
-    # test_retrieve_marinetraffic_data()
-    test_init_scraper()
-    test_marinetraffic_metadict()
-    test_vessel_finder()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,13 @@ dependencies = [
 ]
 zip-safe = false
 version = "1.7.1"
-readme = "readme.rst"
 description = "Smart AIS data storage and integration"
 classifiers = [
-    "Topic :: Communications :: Ham Radio", "Topic :: Database :: Database Engines/Servers", "Topic :: Database :: Front-Ends",
     "Operating System :: POSIX :: Linux", "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Information Analysis", "Topic :: Utilities", "Programming Language :: JavaScript",
     "Topic :: Scientific/Engineering :: GIS", "Intended Audience :: Developers", "Intended Audience :: Science/Research",
     "Programming Language :: SQL", "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Topic :: Database :: Database Engines/Servers", "Topic :: Database :: Front-Ends",
     "Programming Language :: Python :: 3.10", "Programming Language :: Rust",
 ]
 


### PR DESCRIPTION
The update removes lines that allow scripts to be run directly in "test_014_marinetraffic.py", which makes tests cleaner and more modularized. Besides, the order and organization of classifiers were tidied up in "pyproject.toml", improving readability and maintenance.