### PR TITLE
Improve CSV parsing and ETA handling

### DIFF
--- a/aisdb_lib/src/csvreader.rs
+++ b/aisdb_lib/src/csvreader.rs
@@ -383,7 +383,7 @@ pub fn sqlite_decodemsgs_noaa_csv(
     let mut stat_msgs = <Vec<VesselData>>::new();
     let mut positions = <Vec<VesselData>>::new();
     let mut count = 0;
-    // let mut static_seen: HashSet<u32> = HashSet::new(); // 
+    let mut static_seen: HashSet<u32> = HashSet::new();
 
     let mut c = get_db_conn(dbpath).expect("getting db conn");
 
@@ -394,7 +394,7 @@ pub fn sqlite_decodemsgs_noaa_csv(
         let epoch = match iso8601_2_epoch(row_clone.get(1).as_ref().unwrap()) {
             Some(epoch) => epoch as i32,
             None => {
-                eprintln!("Skipping row due to invalid timestamp: {:?}", row_cl$
+                eprintln!("Skipping row due to invalid timestamp: {:?}", row_clone.get(1));
                 return Ok(());
             }
         };
@@ -445,7 +445,6 @@ pub fn sqlite_decodemsgs_noaa_csv(
                     Some("B") => AisClass::ClassB,
                     _ => AisClass::Unknown,
                 },
-                // mmsi: row.get(0).unwrap().parse().unwrap(),
                 mmsi: mmsi,
                 ais_version_indicator: 0, // NOAA does not contain such info but an u8 data type is enforced, we give default value 0 same with unsuccessful parsing result from Spire
                 imo_number: row.get(8).unwrap().parse().ok(),
@@ -543,7 +542,7 @@ pub fn postgres_decodemsgs_noaa_csv(
         let epoch = match iso8601_2_epoch(row_clone.get(1).as_ref().unwrap()) {
             Some(epoch) => epoch as i32,
             None => {
-                eprintln!("Skipping row due to invalid timestamp: {:?}", row_cl$
+                eprintln!("Skipping row due to invalid timestamp: {:?}", row_clone.get(1));
                 return Ok(());
             }
         };

--- a/aisdb_lib/src/csvreader.rs
+++ b/aisdb_lib/src/csvreader.rs
@@ -404,7 +404,13 @@ pub fn sqlite_decodemsgs_noaa_csv(
                 return Ok(());
             }
         };
-        let mmsi: u32 = row.get(0).unwrap().parse().unwrap();
+        let mmsi: u32 = match row.get(0).and_then(|m| m.parse::<u32>().ok()) {
+            Some(mmsi) => mmsi,
+            None => {
+                eprintln!("Skipping row due to invalid MMSI: {:?}", row.get(0));
+                continue; // Skip this row and move to the next one
+            }
+        };
         let payload_dynamic = VesselDynamicData {
             own_vessel: true,
             station: Station::BaseStation,
@@ -558,7 +564,14 @@ pub fn postgres_decodemsgs_noaa_csv(
                 return Ok(());
             }
         };
-        let mmsi: u32 = row.get(0).unwrap().parse().unwrap();
+        let mmsi: u32 = match row.get(0).and_then(|m| m.parse::<u32>().ok()) {
+            Some(mmsi) => mmsi,
+            None => {
+                eprintln!("Skipping row due to invalid MMSI: {:?}", row.get(0));
+                continue; // Skip this row and move to the next one
+            }
+        };
+        
         let payload_dynamic = VesselDynamicData {
             own_vessel: true,
             station: Station::BaseStation,

--- a/aisdb_lib/src/csvreader.rs
+++ b/aisdb_lib/src/csvreader.rs
@@ -21,18 +21,6 @@ use crate::decode::VesselData;
 
 const BATCHSIZE: usize = 50000;
 
-// /// convert time string to epoch seconds
-// pub fn csvdt_2_epoch(dt: &str) -> i64 {
-//     let mut utctime = NaiveDateTime::parse_from_str(dt, "%Y%m%d_%H%M%S");
-//     if let Err(_e) = utctime {
-//         utctime = NaiveDateTime::parse_from_str(dt, "%Y%m%dT%H%M%SZ")
-//     }
-//     if let Err(e) = utctime {
-//         panic!("parsing timestamp from '{}': {}", dt, e);
-//     }
-//     Utc.from_utc_datetime(&utctime.unwrap()).timestamp()
-// }
-
 /// Convert time string to epoch seconds
 pub fn csvdt_2_epoch(dt: &str) -> Result<i64, String> {
     let utctime = NaiveDateTime::parse_from_str(dt, "%Y%m%d_%H%M%S")
@@ -46,11 +34,7 @@ pub fn csvdt_2_epoch(dt: &str) -> Result<i64, String> {
 
 /// filter everything but vessel data, sort vessel data into static and dynamic vectors
 pub fn filter_vesseldata_csv(rowopt: Option<StringRecord>) -> Option<(StringRecord, i32, bool)> {
-    /*
-    if rowopt.is_none() {
-    return None;
-    }
-    */
+    
     rowopt.as_ref()?;
 
     let row = rowopt.unwrap();
@@ -197,12 +181,6 @@ pub fn sqlite_decodemsgs_ee_csv(
     let f3 = filename.to_str().unwrap();
     let f4 = Path::new(f3);
     let fname = f4.file_name().unwrap().to_str().unwrap();
-//     let fname = filename
-//         .to_str()
-//         .unwrap()
-//         .rsplit_once(std::path::MAIN_SEPARATOR)
-//         .unwrap()
-//         .1;
     let fname1 = format!("{:<1$}", fname, 64);
     let elapsed1 = format!(
         "elapsed: {:>1$}s",
@@ -254,7 +232,6 @@ pub fn postgres_decodemsgs_ee_csv(
                 own_vessel: true,
                 station: Station::BaseStation,
                 ais_type: AisClass::Unknown,
-                // mmsi: row.get(0).unwrap().parse().unwrap(),
                 mmsi: row.get(0).unwrap().parse::<u32>().unwrap_or(0),  // make tolerant with invalid MMSIs
                 nav_status: NavigationStatus::NotDefined,
                 rot: row.get(25).unwrap().parse::<f64>().ok(),
@@ -337,12 +314,6 @@ pub fn postgres_decodemsgs_ee_csv(
     let f3 = filename.to_str().unwrap();
     let f4 = Path::new(f3);
     let fname = f4.file_name().unwrap().to_str().unwrap();
-//     let fname = filename
-//         .to_str()
-//         .unwrap()
-//         .rsplit_once(std::path::MAIN_SEPARATOR)
-//         .unwrap()
-//         .1;
     let fname1 = format!("{:<1$}", fname, 64);
     let elapsed1 = format!(
         "elapsed: {:>1$}s",
@@ -393,7 +364,7 @@ pub fn sqlite_decodemsgs_noaa_csv(
             Ok(row) => row,
             Err(err) => {
                 eprintln!("Skipping row due to CSV parsing error: {}", err);
-                continue; // Skip this row and proceed with the next one
+                continue; // Skip the row and proceed with the next one
             }
         };
         let row_clone = row.clone();
@@ -408,7 +379,7 @@ pub fn sqlite_decodemsgs_noaa_csv(
             Some(mmsi) => mmsi,
             None => {
                 eprintln!("Skipping row due to invalid MMSI: {:?}", row.get(0));
-                continue; // Skip this row and move to the next one
+                continue; // Skip the row and move to the next one
             }
         };
         let payload_dynamic = VesselDynamicData {
@@ -581,7 +552,6 @@ pub fn postgres_decodemsgs_noaa_csv(
                 Some("B") => AisClass::ClassB,
                 _ => AisClass::Unknown,
             },
-            // mmsi: row.get(0).unwrap().parse().unwrap(),
             mmsi: mmsi,
             nav_status: NavigationStatus::new(row.get(11).unwrap().parse().unwrap_or_default()),
             rot: None,
@@ -620,7 +590,6 @@ pub fn postgres_decodemsgs_noaa_csv(
                     Some("B") => AisClass::ClassB,
                     _ => AisClass::Unknown,
                 },
-                // mmsi: row.get(0).unwrap().parse().unwrap(),
                 mmsi: mmsi,
                 ais_version_indicator: 0,
                 imo_number: row.get(8).unwrap().parse().ok(),

--- a/aisdb_lib/src/csvreader.rs
+++ b/aisdb_lib/src/csvreader.rs
@@ -389,7 +389,13 @@ pub fn sqlite_decodemsgs_noaa_csv(
 
     for row_option in reader.records(){
         count += 1;
-        let row = row_option.unwrap();
+        let row = match row_option {
+            Ok(row) => row,
+            Err(err) => {
+                eprintln!("Skipping row due to CSV parsing error: {}", err);
+                continue; // Skip this row and proceed with the next one
+            }
+        };
         let row_clone = row.clone();
         let epoch = match iso8601_2_epoch(row_clone.get(1).as_ref().unwrap()) {
             Some(epoch) => epoch as i32,
@@ -537,7 +543,13 @@ pub fn postgres_decodemsgs_noaa_csv(
 
     for row_option in reader.records(){
         count += 1;
-        let row = row_option.unwrap();
+        let row = match row_option {
+            Ok(row) => row,
+            Err(err) => {
+                eprintln!("Skipping row due to CSV parsing error: {}", err);
+                continue; // Skip this row and proceed with the next one
+            }
+        };
         let row_clone = row.clone();
         let epoch = match iso8601_2_epoch(row_clone.get(1).as_ref().unwrap()) {
             Some(epoch) => epoch as i32,

--- a/aisdb_lib/src/decode.rs
+++ b/aisdb_lib/src/decode.rs
@@ -126,64 +126,6 @@ fn is_valid_epoch(epoch: u64) -> bool {
     epoch >= min_valid_epoch && epoch <= current_time
 }
 
-// pub fn parse_headers(line: Result<String, Error>) -> Option<(String, i32)> {
-//     let (meta, payload) = line.as_ref().unwrap().rsplit_once('\\')?;
-//     for tag_outer in meta.split(',') {
-//         for tag in tag_outer.split('*') {
-//             if tag.len() <= 3 || !&tag.contains("c:") {
-//                 continue;
-//             } else if let Ok(i) = tag[2..].parse::<i32>() {
-//                 return Some((payload.to_string(), i));
-//             } else if let Ok(i) = tag[3..].parse::<i32>() {
-//                 return Some((payload.to_string(), i));
-//             } else if let Ok(i) = tag.split_once(' ').unwrap_or(("", "")).0.parse::<u64>() {
-//                 if 946731600 < i
-//                     && i <= std::time::SystemTime::now()
-//                         .duration_since(std::time::UNIX_EPOCH)
-//                         .unwrap()
-//                         .as_secs()
-//                 {
-//                     return Some((payload.to_string(), i.try_into().unwrap()));
-//                 } else {
-//                     //                     #[cfg(debug_assertions)]
-//                     //                     println!(
-//                     //                         "skipped- tag:{:?}\tmeta:{:?}\tpayload:{:?}",
-//                     //                         tag, meta, payload
-//                     //                     );
-//                     return None;
-//                 }
-//             }
-//         }
-//     }
-//     if meta.contains(' ') {
-//         //         #[cfg(debug_assertions)]
-//         //         println!("{:?}", meta);
-//         let ii = meta.split_once(' ').unwrap().0.parse::<u64>().unwrap_or(0);
-//         if ii == 0 {
-//             return None;
-//         }
-//
-//         let now = std::time::SystemTime::now()
-//             .duration_since(std::time::UNIX_EPOCH)
-//             .unwrap()
-//             .as_secs();
-//         if 946731600 < ii && ii <= now {
-//             Some((payload.to_string(), ii.try_into().unwrap()))
-//         } else {
-//             //             #[cfg(debug_assertions)]
-//             //             println!(
-//             //                 "skipped- ii:{:?}\tmeta:{:?}\tpayload:{:?}",
-//             //                 ii, meta, payload
-//             //             );
-//             None
-//         }
-//     } else {
-//         //         #[cfg(debug_assertions)]
-//         //         println!("skipped- meta:{:?}\tpayload:{:?}", meta, payload);
-//         None
-//     }
-// }
-
 
 fn extract_epoch_from_nmea_line(line: &str) -> i32 {
     // Attempt to extract Unix timestamp from additional fields after the checksum

--- a/aisdb_lib/src/util.rs
+++ b/aisdb_lib/src/util.rs
@@ -25,7 +25,7 @@ OPTIONS:
 
 use std::fs::read_dir;
 
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 
 /// yields sorted vector of files in dirname with a matching file extension.
 pub fn glob_dir(dirname: std::path::PathBuf, matching: &str) -> Option<Vec<String>> {
@@ -41,8 +41,7 @@ pub fn glob_dir(dirname: std::path::PathBuf, matching: &str) -> Option<Vec<Strin
 }
 
 pub fn epoch_2_dt(e: i64) -> DateTime<Utc> {
-    let time = NaiveDateTime::from_timestamp_opt(e, 0).expect("getting current timestamp");
-    Utc.from_utc_datetime(&time)
+    DateTime::from_timestamp(e, 0).expect("getting current timestamp")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Main changes from this branch:
- Optimized NOAA CSV parsing to prevent memory issues by storing only unique ship information instead of static info from the entire dataset. This prevents dynamic and static vessel objects from growing synchronously and exceeding memory limits that previously caused processes to stuck.
- Fixed processing thread panics caused by MMSI and timestamp parsing errors, and row column mismatches.
- Added support for parsing ETA fields from Spire CSVs.